### PR TITLE
Adjust speed_bonus_calc to be an integer for easier logging

### DIFF
--- a/onefiveone/learn.py
+++ b/onefiveone/learn.py
@@ -397,7 +397,7 @@ class PyBoyEnv(gym.Env):
             )
             self.last_total_items = carried_item_total + stored_item_total
 
-        speed_bonus_calc = (self.max_frames - self.frames) / (self.max_frames + 1)
+        speed_bonus_calc = (self.max_frames - self.frames) // (self.max_frames + 1)
 
         if caught_pokemon_start < caught_pokemon_end:
             pokemon_caught = np.sum(


### PR DESCRIPTION
Fixes logging in tensoboard, uses integers instead of float