### PR TITLE
Travel and money reward updates

### DIFF
--- a/onefiveone/emulator/pyboy_env.py
+++ b/onefiveone/emulator/pyboy_env.py
@@ -420,11 +420,6 @@ class PyBoyEnv(gym.Env):
         py = location[2]
         pbx = location[3]
         pby = location[4]
-
-        # Early escape for starting maps
-        if (map_id == 38 and (px == 6 and py == 3 and pbx == 0 and pby == 1) or (px == 6 and py == 1 and pbx == 0 and pby == 1)) or map_id == 0 and ((px == 0 and py == 0 and pbx == 0 and pby == 0) or (px == 6 and py == 4 and pbx == 0 and pby == 0)):
-            reward = 0
-            return round(reward, 4), self.last_n_memories
         
         self.my_pokemon = my_pokemon
 
@@ -610,8 +605,7 @@ class PyBoyEnv(gym.Env):
             money_divider = 1000
             if money > old_money:
                 money_divider = 500
-
-            money_reward = np.abs(money - old_money) / money_divider
+                money_reward = np.abs(money - old_money) / money_divider
 
         
         reward += (

--- a/onefiveone/emulator/pyboy_env.py
+++ b/onefiveone/emulator/pyboy_env.py
@@ -445,7 +445,7 @@ class PyBoyEnv(gym.Env):
             if chunk_id in self.visited_xy:
                 # TODO: restore negative and positive rewards for visiting new chunks and revisiting cold ones
                 # Targeted for after issue #10 is resolved.
-                visited_score = -0.2
+                visited_score = 0.01
                 pass
             else:
                 self.visited_xy.add(chunk_id)


### PR DESCRIPTION
Remove the reward mute in early game: this turned out to be a bug where I was saving and loading a RAM state by mistake due to how I was calling pyboy.stop().  Also update the travel reward to remove penalty for revisiting locations.  However, remaining stationary still incurs a slight penalty (hopefully offset by combat or by catching a pokemon later)

This also fixes the money reward so that the trainer is not rewarded (or penalized) for losing money / spending money, but is rewarded for gaining it.