### PR TITLE
Segmenting input space for better learning

### DIFF
--- a/onefiveone/emulator/pyboy_env.py
+++ b/onefiveone/emulator/pyboy_env.py
@@ -7,7 +7,7 @@ import hashlib
 import numpy as np
 
 import gymnasium as gym
-from gymnasium.spaces import Box, Discrete
+from gymnasium.spaces import Box, Discrete, Dict
 from gymnasium import spaces
 
 # Emulator libs
@@ -116,9 +116,18 @@ class PyBoyEnv(gym.Env):
         )
         self.screen_space = Box(low=0, high=255, shape=(144, 160, 4), dtype=np.uint8)
 
-        self.location_space = Box(low=0, high=255, shape=(3,), dtype=np.uint8)
+        self.map_space = Discrete(256)
+        self.coord_space = Box(low=0, high=255, shape=(2,), dtype=np.uint8)
+        self.location_space = Dict({
+            "map_id": self.map_space,
+            "coords": self.coord_space
+        })
 
-        self.observation_space = spaces.Dict({"m":self.memory_space, "s":self.screen_space, "l":self.location_space})
+        self.observation_space = spaces.Dict({
+            "m": self.memory_space,
+            "s": self.screen_space,
+            "l": self.location_space
+        })
 
         self.action_space = Discrete(8, start=0) # 8 buttons to press, only one pressed at a time
         
@@ -661,7 +670,14 @@ class PyBoyEnv(gym.Env):
 
 
         self.total_reward += reward
-        return round(reward, 4), {"m":self.last_n_memories, "s":self.pyboy.screen.ndarray.copy(), "l":[px, py, map_id]}
+        return round(reward, 4), {
+            "m": self.last_n_memories,
+            "s": self.pyboy.screen.ndarray.copy(),
+            "l": {
+                "map_id": map_id,
+                "coords": [px, py]
+            }
+        }
 
 
     def render(self, target_index=None, reset=False):

--- a/onefiveone/emulator/pyboy_env.py
+++ b/onefiveone/emulator/pyboy_env.py
@@ -118,15 +118,12 @@ class PyBoyEnv(gym.Env):
 
         self.map_space = Discrete(256)
         self.coord_space = Box(low=0, high=255, shape=(2,), dtype=np.uint8)
-        self.location_space = Dict({
-            "map_id": self.map_space,
-            "coords": self.coord_space
-        })
 
         self.observation_space = spaces.Dict({
             "m": self.memory_space,
             "s": self.screen_space,
-            "l": self.location_space
+            "map_id": self.map_space,
+            "coords": self.coord_space
         })
 
         self.action_space = Discrete(8, start=0) # 8 buttons to press, only one pressed at a time
@@ -673,10 +670,8 @@ class PyBoyEnv(gym.Env):
         return round(reward, 4), {
             "m": self.last_n_memories,
             "s": self.pyboy.screen.ndarray.copy(),
-            "l": {
-                "map_id": map_id,
-                "coords": [px, py]
-            }
+            "map_id": map_id,
+            "coords": [px, py]
         }
 
 

--- a/onefiveone/learn.py
+++ b/onefiveone/learn.py
@@ -215,12 +215,15 @@ def train_model(
         n_epochs=3,
         gamma=0.99,  # Reduced from 0.998
         gae_lambda=0.98,
-        # learning_rate=learning_rate_schedule,
+        learning_rate=learning_rate_schedule,
         # learning_rate=learning_rate_decay_schedule,
         ent_coef=0.02,
         env=env,
         policy_kwargs=policy_kwargs,
         verbose=0,
+        clip_range=0.2,    
+        vf_coef=0.5,       
+        max_grad_norm=0.5,
         device=device,
     )
 

--- a/onefiveone/learn.py
+++ b/onefiveone/learn.py
@@ -10,8 +10,6 @@ import numpy as np
 import torch
 
 
-import gymnasium as gym
-from gymnasium.spaces import Box, Discrete
 from stable_baselines3 import PPO
 
 from stable_baselines3.common.callbacks import (


### PR DESCRIPTION
Currently, after a very short preiod of time the model gets to the point where it will fight in the tall grass above pallete town, but it never makes it to the next town, getting caught in a cycle of battling wild pokemon and exploring corners of the map.  The screen its own separate input already, but I'd like to also adjust it so that location data is separate, perhaps more easily interpreted as "relative to starting location" rather than trying to keep track of what the different maps mean.  That is, instead of jumping from map 0 to map 38 when the player hits an XY boundry, we reward the transition to another map but track location based on total relative position.